### PR TITLE
REDIS_ADDR should always be used for master/slave connections

### DIFF
--- a/resec/consul/new.go
+++ b/resec/consul/new.go
@@ -16,6 +16,7 @@ import (
 
 func NewConnection(c *cli.Context, redisConfig redis.Config) (*Manager, error) {
 	consulConfig := &config{
+        redisAddr:                redisConfig.Address,
 		deregisterServiceAfter:   c.Duration("consul-deregister-service-after"),
 		lockKey:                  c.String("consul-lock-key"),
 		lockMonitorRetries:       c.Int("consul-lock-monitor-retries"),
@@ -58,17 +59,17 @@ func NewConnection(c *cli.Context, redisConfig redis.Config) (*Manager, error) {
 		redisHost := strings.Split(redisConfig.Address, ":")[0]
 		redisPort := strings.Split(redisConfig.Address, ":")[1]
 		if redisHost == "127.0.0.1" || redisHost == "localhost" || redisHost == "::1" {
-			consulConfig.announceAddr = ":" + redisPort
+			announceAddr = ":" + redisPort
 		} else {
-			consulConfig.announceAddr = redisConfig.Address
+			announceAddr = redisConfig.Address
 		}
 	}
 
 	var err error
-	consulConfig.announceHost = strings.Split(consulConfig.announceAddr, ":")[0]
-	consulConfig.announcePort, err = strconv.Atoi(strings.Split(consulConfig.announceAddr, ":")[1])
+	consulConfig.announceHost = strings.Split(announceAddr, ":")[0]
+	consulConfig.announcePort, err = strconv.Atoi(strings.Split(announceAddr, ":")[1])
 	if err != nil {
-		return nil, fmt.Errorf("Trouble extracting port number from [%s]", redisConfig.Address)
+		return nil, fmt.Errorf("Trouble extracting port number from [%s]", announceAddr)
 	}
 
 	instance := &Manager{

--- a/resec/consul/structs.go
+++ b/resec/consul/structs.go
@@ -26,7 +26,7 @@ type Manager struct {
 
 // Consul config used for internal state management
 type config struct {
-	announceAddr             string              // address (IP:port) to announce to Consul
+	redisAddr                string              // actual redis address of this node used for master/slave reporting inside redis
 	announceHost             string              // host (IP) to announce to Consul
 	announcePort             int                 // port to announce to Consul
 	checkID                  string              // consul check ID


### PR DESCRIPTION
ANNOUNCE_ADDR should be used as the address consul reports to clients.
REDIS_ADDR should always be used internally for SLAVEOF operations.